### PR TITLE
Use getBoundingClientRect instead of offset

### DIFF
--- a/jquery.overlaps.js
+++ b/jquery.overlaps.js
@@ -48,10 +48,10 @@
         var dims = [], i = 0, offset, elem;
 
         while ((elem = elems[i++])) {
-            offset = $(elem).offset();
+            offset = elem.getBoundingClientRect();
             dims.push([
-                offset.top,
-                offset.left,
+                offset.top + document.body.scrollTop,
+                offset.left + document.body.scrollTLeft,
                 elem.offsetWidth,
                 elem.offsetHeight
             ]);

--- a/jquery.overlaps.js
+++ b/jquery.overlaps.js
@@ -51,7 +51,7 @@
             offset = elem.getBoundingClientRect();
             dims.push([
                 offset.top + document.body.scrollTop,
-                offset.left + document.body.scrollTLeft,
+                offset.left + document.body.scrollLeft,
                 elem.offsetWidth,
                 elem.offsetHeight
             ]);


### PR DESCRIPTION
Replace jQuery’s offset with getBoundingClientRect for performance, as suggested on issue #11 